### PR TITLE
Fix: handle whitespaces in paths

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'dart:async';
 import 'package:flutter/services.dart';
 
-import "package:path_provider/path_provider.dart";
 import 'package:mecab_dart/mecab_dart.dart';
 
 void main() => runApp(MyApp());
@@ -17,7 +16,7 @@ class _MyAppState extends State<MyApp> {
   TextEditingController controller =
     TextEditingController(text: 'にわにわにわにわとりがいる。');
   /// used platform version
-  String _platformVersion = 'Unknown';
+  String platformVersion = 'Unknown';
   /// result of mecab
   String text = "";
   /// mecab instance
@@ -34,7 +33,7 @@ class _MyAppState extends State<MyApp> {
   Future<void> initPlatformState() async {
     String platformVersion;    
     try {
-      platformVersion = await MecabDart.platformVersion;
+      platformVersion = await Mecab.platformVersion;
 
       // Initialize mecab tagger here 
       //   + 1st parameter : dictionary asset folder
@@ -50,7 +49,7 @@ class _MyAppState extends State<MyApp> {
     if (!mounted) return;
 
     setState(() {
-      _platformVersion = platformVersion;
+      platformVersion = platformVersion;
       print(platformVersion);
     });
   }

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
 DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
   - mecab_dart (from `Flutter/ephemeral/.symlinks/plugins/mecab_dart/macos`)
-  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/macos`)
+  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
 
 EXTERNAL SOURCES:
   FlutterMacOS:
@@ -17,13 +17,13 @@ EXTERNAL SOURCES:
   mecab_dart:
     :path: Flutter/ephemeral/.symlinks/plugins/mecab_dart/macos
   path_provider_foundation:
-    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/macos
+    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
 
 SPEC CHECKSUMS:
-  FlutterMacOS: ae6af50a8ea7d6103d888583d46bd8328a7e9811
+  FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   mecab_dart: 5082f14a3f6a9d0cf0b22a26a9ac2bfec2326064
   path_provider_foundation: 37748e03f12783f9de2cb2c4eadfaa25fe6d4852
 
-PODFILE CHECKSUM: 6eac6b3292e5142cfc23bdeb71848a40ec51c14c
+PODFILE CHECKSUM: 353c8bcc5d5b0994e508d035b5431cfe18c1dea7
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.14.3

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -203,7 +203,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					33CC10EC2044A3C60003C045 = {
@@ -256,6 +256,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -404,7 +405,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -483,7 +484,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -530,7 +531,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,63 +5,64 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
-  cupertino_icons:
-    dependency: "direct main"
-    description:
-      name: cupertino_icons
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.3"
+    version: "1.18.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   ffi:
     dependency: transitive
     description:
       name: ffi
-      url: "https://pub.dartlang.org"
+      sha256: a38574032c5f1dd06c4aee541789906c12ccaab8ba01446e800d9c5b79c4a978
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
   flutter:
@@ -74,20 +75,46 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.4"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.8.0"
   mecab_dart:
     dependency: "direct main"
     description:
@@ -99,77 +126,88 @@ packages:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.12.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   path_provider:
     dependency: transitive
     description:
       name: path_provider
-      url: "https://pub.dartlang.org"
+      sha256: dcea5feb97d8abf90cab9e9030b497fb7c3cbf26b7a1fe9e3ef7dcb0a1ddec95
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.12"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
-      url: "https://pub.dartlang.org"
+      sha256: a776c088d671b27f6e3aa8881d64b87b3e80201c64e8869b811325de7a76c15e
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.22"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      url: "https://pub.dartlang.org"
+      sha256: "62a68e7e1c6c459f9289859e2fae58290c981ce21d1697faf54910fe1faa4c74"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
-      url: "https://pub.dartlang.org"
+      sha256: ab0987bf95bc591da42dffb38c77398fc43309f0b9b894dcc5d6f40c4b26c379
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.7"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: f0abc8ebd7253741f05488b4813d936b4d07c6bae3e86148a09e342ee4b08e76
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.5"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
-      url: "https://pub.dartlang.org"
+      sha256: bcabbe399d4042b8ee687e17548d5d3f527255253b4a639f5f8d2094a9c2b45c
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   platform:
     dependency: transitive
     description:
       name: platform
-      url: "https://pub.dartlang.org"
+      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: dbf0f707c78beedc9200146ad3cb0ab4d5da13c246336987be6940f026500d3a
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   process:
     dependency: transitive
     description:
       name: process
-      url: "https://pub.dartlang.org"
+      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
+      url: "https://pub.dev"
     source: hosted
     version: "4.2.4"
   sky_engine:
@@ -181,65 +219,82 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.7.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.2.1"
   win32:
     dependency: transitive
     description:
       name: win32
-      url: "https://pub.dartlang.org"
+      sha256: c9ebe7ee4ab0c2194e65d3a07d8c54c5d00bb001b76081c4a04cdb8448b59e46
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
-      url: "https://pub.dartlang.org"
+      sha256: bd512f03919aac5f1313eb8249f223bacf4927031bf60b02601f81f687689e86
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.0+3"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
-  flutter: ">=3.0.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -21,10 +21,6 @@ dependencies:
   flutter:
     sdk: flutter
 
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.2
-
   # Mecab dart wrapper
   mecab_dart:
     path: ../
@@ -33,46 +29,9 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
 
-# The following section is specific to Flutter.
 flutter:
   assets:
     - assets/ipadic/
 
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
   uses-material-design: true
-
-  # To add assets to your application, add an assets section, like this:
-  # assets:
-  #  - images/a_dot_burr.jpeg
-  #  - images/a_dot_ham.jpeg
-
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.dev/assets-and-images/#from-packages
-
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts from package dependencies,
-  # see https://flutter.dev/custom-fonts/#from-packages

--- a/ios/Classes/dart_ffi.cpp
+++ b/ios/Classes/dart_ffi.cpp
@@ -1,50 +1,54 @@
-//  MeCab -- Yet Another Part-of-Speech and Morphological Analyzer
-//
-//
-//  Copyright(C) 2001-2006 Taku Kudo <taku@chasen.org>
-//  Copyright(C) 2004-2006 Nippon Telegraph and Telephone Corporation
-
-//  Flutter Dart binding by Tung Duong - 2020
-
 #include "mecab.h"
 #include <vector>
 #include <string>
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
 
-std::vector<char*> split(std::string st) {
+// Function to split options string into arguments, respecting quotes
+std::vector<char*> parseOptions(const std::string& options) {
     std::vector<char*> result;
-    size_t start = 0;
-    while(start < st.length()) {
-        while(st[start] == ' ') start ++;
-        size_t end = start + 1;
-        while(end < st.length() && st[end] != ' ') end ++;
-        char* token = (char*) malloc(end - start + 1);
-        strncpy(token, st.data() + start, end - start);
-        token[end - start] = 0;
-	    result.push_back(token);
-        start = end + 1;
+    std::string token;
+    bool inQuotes = false;
+
+    for (char ch : options) {
+        if (ch == '"') {
+            inQuotes = !inQuotes;
+        } else if (ch == ' ' && !inQuotes) {
+            if (!token.empty()) {
+                char* arg = (char*)malloc(token.size() + 1);
+                strcpy(arg, token.c_str());
+                result.push_back(arg);
+                token.clear();
+            }
+        } else {
+            token += ch;
+        }
     }
+    if (!token.empty()) {
+        char* arg = (char*)malloc(token.size() + 1);
+        strcpy(arg, token.c_str());
+        result.push_back(arg);
+    }
+
     return result;
 }
 
 extern "C" __attribute__((visibility("default"))) __attribute__((used))
 void* initMecab(const char* opt, const char* dicdir) {
     std::string rcfile = std::string(dicdir) + "/mecabrc";
-    FILE *f = fopen(rcfile.data(), "rt");
-    if(!f) return NULL;
+    FILE* f = fopen(rcfile.c_str(), "rt");
+    if (!f) return NULL;
+    fclose(f);
 
-    std::string options = (std::string) "mecab --rcfile=" + (std::string) rcfile 
-                                         + " --dicdir=" + dicdir;
-    if(*opt) {
+    std::string options = "mecab --rcfile=\"" + rcfile + "\" --dicdir=\"" + std::string(dicdir) + "\"";
+    if (*opt) {
         options += " " + std::string(opt);
-    }                       
+    }
 
-    std::vector<char*> params = split(options);
+    std::vector<char*> params = parseOptions(options);
     mecab_t* mecab = mecab_new(params.size(), params.data());
 
-    for(size_t i = 0; i < params.size(); i++) {
+    for (size_t i = 0; i < params.size(); ++i) {
         free(params[i]);
     }
 
@@ -52,15 +56,15 @@ void* initMecab(const char* opt, const char* dicdir) {
 }
 
 extern "C" __attribute__((visibility("default"))) __attribute__((used))
-const char* parse(void* mecab, const char* input) { 
-    if(!mecab) return ""; 
+const char* parse(void* mecab, const char* input) {
+    if (!mecab) return "";
     return mecab_sparse_tostr((mecab_t*)mecab, input);
 }
 
 extern "C" __attribute__((visibility("default"))) __attribute__((used))
 void destroyMecab(void* mecab) {
-    if(mecab) {
-        mecab_destroy((mecab_t*) mecab);  
+    if (mecab) {
+        mecab_destroy((mecab_t*)mecab);
     }
 }
 

--- a/macos/Classes/dart_ffi.cpp
+++ b/macos/Classes/dart_ffi.cpp
@@ -1,50 +1,54 @@
-//  MeCab -- Yet Another Part-of-Speech and Morphological Analyzer
-//
-//
-//  Copyright(C) 2001-2006 Taku Kudo <taku@chasen.org>
-//  Copyright(C) 2004-2006 Nippon Telegraph and Telephone Corporation
-
-//  Flutter Dart binding by Tung Duong - 2020
-
 #include "mecab.h"
 #include <vector>
 #include <string>
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
 
-std::vector<char*> split(std::string st) {
+// Function to split options string into arguments, respecting quotes
+std::vector<char*> parseOptions(const std::string& options) {
     std::vector<char*> result;
-    size_t start = 0;
-    while(start < st.length()) {
-        while(st[start] == ' ') start ++;
-        size_t end = start + 1;
-        while(end < st.length() && st[end] != ' ') end ++;
-        char* token = (char*) malloc(end - start + 1);
-        strncpy(token, st.data() + start, end - start);
-        token[end - start] = 0;
-	    result.push_back(token);
-        start = end + 1;
+    std::string token;
+    bool inQuotes = false;
+
+    for (char ch : options) {
+        if (ch == '"') {
+            inQuotes = !inQuotes;
+        } else if (ch == ' ' && !inQuotes) {
+            if (!token.empty()) {
+                char* arg = (char*)malloc(token.size() + 1);
+                strcpy(arg, token.c_str());
+                result.push_back(arg);
+                token.clear();
+            }
+        } else {
+            token += ch;
+        }
     }
+    if (!token.empty()) {
+        char* arg = (char*)malloc(token.size() + 1);
+        strcpy(arg, token.c_str());
+        result.push_back(arg);
+    }
+
     return result;
 }
 
 extern "C" __attribute__((visibility("default"))) __attribute__((used))
 void* initMecab(const char* opt, const char* dicdir) {
     std::string rcfile = std::string(dicdir) + "/mecabrc";
-    FILE *f = fopen(rcfile.data(), "rt");
-    if(!f) return NULL;
+    FILE* f = fopen(rcfile.c_str(), "rt");
+    if (!f) return NULL;
+    fclose(f);
 
-    std::string options = (std::string) "mecab --rcfile=" + (std::string) rcfile 
-                                         + " --dicdir=" + dicdir;
-    if(*opt) {
+    std::string options = "mecab --rcfile=\"" + rcfile + "\" --dicdir=\"" + std::string(dicdir) + "\"";
+    if (*opt) {
         options += " " + std::string(opt);
-    }                       
+    }
 
-    std::vector<char*> params = split(options);
+    std::vector<char*> params = parseOptions(options);
     mecab_t* mecab = mecab_new(params.size(), params.data());
 
-    for(size_t i = 0; i < params.size(); i++) {
+    for (size_t i = 0; i < params.size(); ++i) {
         free(params[i]);
     }
 
@@ -52,15 +56,15 @@ void* initMecab(const char* opt, const char* dicdir) {
 }
 
 extern "C" __attribute__((visibility("default"))) __attribute__((used))
-const char* parse(void* mecab, const char* input) { 
-    if(!mecab) return ""; 
+const char* parse(void* mecab, const char* input) {
+    if (!mecab) return "";
     return mecab_sparse_tostr((mecab_t*)mecab, input);
 }
 
 extern "C" __attribute__((visibility("default"))) __attribute__((used))
 void destroyMecab(void* mecab) {
-    if(mecab) {
-        mecab_destroy((mecab_t*) mecab);  
+    if (mecab) {
+        mecab_destroy((mecab_t*)mecab);
     }
 }
 

--- a/windows/src/dart_ffi.cpp
+++ b/windows/src/dart_ffi.cpp
@@ -1,65 +1,74 @@
-//  MeCab -- Yet Another Part-of-Speech and Morphological Analyzer
-//
-//
-//  Copyright(C) 2001-2006 Taku Kudo <taku@chasen.org>
-//  Copyright(C) 2004-2006 Nippon Telegraph and Telephone Corporation
-
-//  Flutter Dart binding by Tung Duong - 2020
-
 #include "mecab.h"
+#include <vector>
+#include <string>
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
-#include "dart_ffi.h"
 
-std::vector<char*> split(std::string st) {
+// Function to split options string into arguments, respecting quotes
+std::vector<char*> parseOptions(const std::string& options) {
     std::vector<char*> result;
-    size_t start = 0;
-    while(start < st.length()) {
-        while(st[start] == ' ') start ++;
-        size_t end = start + 1;
-        while(end < st.length() && st[end] != ' ') end ++;
-        char* token = (char*) malloc(end - start + 1);
-        strncpy(token, st.data() + start, end - start);
-        token[end - start] = 0;
-	    result.push_back(token);
-        start = end + 1;
+    std::string token;
+    bool inQuotes = false;
+
+    for (char ch : options) {
+        if (ch == '"') {
+            inQuotes = !inQuotes;
+        } else if (ch == ' ' && !inQuotes) {
+            if (!token.empty()) {
+                char* arg = (char*)malloc(token.size() + 1);
+                strcpy(arg, token.c_str());
+                result.push_back(arg);
+                token.clear();
+            }
+        } else {
+            token += ch;
+        }
     }
+    if (!token.empty()) {
+        char* arg = (char*)malloc(token.size() + 1);
+        strcpy(arg, token.c_str());
+        result.push_back(arg);
+    }
+
     return result;
 }
 
+extern "C" __attribute__((visibility("default"))) __attribute__((used))
 void* initMecab(const char* opt, const char* dicdir) {
     std::string rcfile = std::string(dicdir) + "/mecabrc";
-    FILE *f = fopen(rcfile.data(), "rt");
-    if(!f) return NULL;
+    FILE* f = fopen(rcfile.c_str(), "rt");
+    if (!f) return NULL;
+    fclose(f);
 
-    std::string options = (std::string) "mecab --rcfile=" + (std::string) rcfile 
-                                         + " --dicdir=" + dicdir;
-    if(*opt) {
+    std::string options = "mecab --rcfile=\"" + rcfile + "\" --dicdir=\"" + std::string(dicdir) + "\"";
+    if (*opt) {
         options += " " + std::string(opt);
-    }                       
+    }
 
-    std::vector<char*> params = split(options);
+    std::vector<char*> params = parseOptions(options);
     mecab_t* mecab = mecab_new(params.size(), params.data());
 
-    for(size_t i = 0; i < params.size(); i++) {
+    for (size_t i = 0; i < params.size(); ++i) {
         free(params[i]);
     }
 
     return mecab;
 }
 
-const char* parse(void* mecab, const char* input) { 
-    if(!mecab) return ""; 
+extern "C" __attribute__((visibility("default"))) __attribute__((used))
+const char* parse(void* mecab, const char* input) {
+    if (!mecab) return "";
     return mecab_sparse_tostr((mecab_t*)mecab, input);
 }
 
+extern "C" __attribute__((visibility("default"))) __attribute__((used))
 void destroyMecab(void* mecab) {
-    if(mecab) {
-        mecab_destroy((mecab_t*) mecab);  
+    if (mecab) {
+        mecab_destroy((mecab_t*)mecab);
     }
 }
 
-int native_add(int x, int y) {
+extern "C" __attribute__((visibility("default"))) __attribute__((used))
+int32_t native_add(int32_t x, int32_t y) {
     return x + y;
 }


### PR DESCRIPTION
The plugin is was not able to load mecab from paths that contain spaces. This could happen when for example a user named his home directory with a space like "FirstName SecondName"